### PR TITLE
Update schema seeds and show user full name on dashboard

### DIFF
--- a/clinicaweb/src/stores/auth.ts
+++ b/clinicaweb/src/stores/auth.ts
@@ -4,6 +4,7 @@ import { defineStore } from 'pinia'
 interface AuthState {
   isAuthenticated: boolean
   userEmail: string | null
+  userFullName: string | null
 }
 
 interface LoginResponse {
@@ -38,6 +39,7 @@ export const useAuthStore = defineStore('auth', {
   state: (): AuthState => ({
     isAuthenticated: false,
     userEmail: null,
+    userFullName: null,
   }),
   actions: {
     async login(email: string, password: string): Promise<LoginResult> {
@@ -49,6 +51,7 @@ export const useAuthStore = defineStore('auth', {
 
         this.isAuthenticated = true
         this.userEmail = response.data.email
+        this.userFullName = response.data.fullName
 
         return {
           success: true,
@@ -57,6 +60,7 @@ export const useAuthStore = defineStore('auth', {
       } catch (error) {
         this.isAuthenticated = false
         this.userEmail = null
+        this.userFullName = null
 
         if (axios.isAxiosError(error)) {
           const message =
@@ -77,6 +81,7 @@ export const useAuthStore = defineStore('auth', {
     logout() {
       this.isAuthenticated = false
       this.userEmail = null
+      this.userFullName = null
     },
   },
 })

--- a/clinicaweb/src/views/DashboardView.vue
+++ b/clinicaweb/src/views/DashboardView.vue
@@ -113,6 +113,11 @@ const router = useRouter()
 const authStore = useAuthStore()
 
 const displayName = computed(() => {
+  const fullName = authStore.userFullName?.trim()
+  if (fullName) {
+    return fullName
+  }
+
   const email = authStore.userEmail
   if (email && email.includes('@')) {
     const namePart = email.split('@')[0]
@@ -120,6 +125,7 @@ const displayName = computed(() => {
       return namePart.charAt(0).toUpperCase() + namePart.slice(1)
     }
   }
+
   return 'Paciente'
 })
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -45,8 +45,7 @@ CREATE TABLE dbo.Usuarios
     NombreCompleto NVARCHAR(200) NOT NULL,
     IdMedico INT NULL,
     Activo BIT NOT NULL DEFAULT (1),
-    FechaCreacion DATETIME2(0) NOT NULL DEFAULT (SYSUTCDATETIME()),
-    CONSTRAINT FK_Usuarios_Medicos FOREIGN KEY (IdMedico) REFERENCES dbo.Medicos (Id)
+    FechaCreacion DATETIME2(0) NOT NULL DEFAULT (SYSUTCDATETIME())
 );
 GO
 
@@ -61,6 +60,58 @@ CREATE TABLE dbo.Consultas
     CONSTRAINT FK_Consultas_Medicos FOREIGN KEY (IdMedico) REFERENCES dbo.Medicos (Id),
     CONSTRAINT FK_Consultas_Pacientes FOREIGN KEY (IdPaciente) REFERENCES dbo.Pacientes (Id)
 );
+GO
+
+INSERT INTO dbo.Medicos (PrimerNombre, SegundoNombre, ApellidoPaterno, ApellidoMaterno, Cedula, Telefono, Especialidad, Email)
+VALUES
+    (N'Carlos', N'Andrés', N'Ramírez', N'González', N'MED001', N'555-0101', N'Cardiología', N'carlos.ramirez@clinica.com'),
+    (N'Lucía', NULL, N'Herrera', N'Mendoza', N'MED002', N'555-0102', N'Pediatría', N'lucia.herrera@clinica.com'),
+    (N'Juan', N'Pablo', N'Gómez', N'Ríos', N'MED003', N'555-0103', N'Dermatología', N'juan.gomez@clinica.com'),
+    (N'Ana', N'Laura', N'Salinas', N'Cano', N'MED004', N'555-0104', N'Ginecología', N'ana.salinas@clinica.com'),
+    (N'Roberto', NULL, N'Cárdenas', N'López', N'MED005', N'555-0105', N'Neurología', N'roberto.cardenas@clinica.com'),
+    (N'Sofía', N'Isabel', N'Morales', N'Quintero', N'MED006', N'555-0106', N'Oncología', N'sofia.morales@clinica.com'),
+    (N'Marco', N'Antonio', N'Silva', N'Campos', N'MED007', N'555-0107', N'Traumatología', N'marco.silva@clinica.com'),
+    (N'Elena', NULL, N'Pérez', N'Valdez', N'MED008', N'555-0108', N'Endocrinología', N'elena.perez@clinica.com'),
+    (N'Diego', N'Armando', N'Navarro', N'Ibáñez', N'MED009', N'555-0109', N'Oftalmología', N'diego.navarro@clinica.com'),
+    (N'Valeria', N'Noemí', N'Blanco', N'Serrano', N'MED010', N'555-0110', N'Psiquiatría', N'valeria.blanco@clinica.com');
+GO
+
+INSERT INTO dbo.Pacientes (PrimerNombre, SegundoNombre, ApellidoPaterno, ApellidoMaterno, Telefono)
+VALUES
+    (N'Luis', N'Alberto', N'Fernández', N'Ruiz', N'555-0201'),
+    (N'María', N'José', N'Camacho', N'López', N'555-0202'),
+    (N'Andrés', NULL, N'Ortega', N'Peña', N'555-0203'),
+    (N'Fernanda', N'Paola', N'Martínez', N'Ramos', N'555-0204'),
+    (N'Javier', N'Enrique', N'Castillo', N'Galván', N'555-0205'),
+    (N'Patricia', NULL, N'Aguilar', N'Soto', N'555-0206'),
+    (N'Ignacio', N'Leonel', N'Reyes', N'Duarte', N'555-0207'),
+    (N'Liliana', N'Beatriz', N'Chávez', N'Carrillo', N'555-0208'),
+    (N'Hugo', NULL, N'Moreno', N'Sandoval', N'555-0209'),
+    (N'Daniela', N'Carolina', N'Pineda', N'Rosales', N'555-0210');
+GO
+
+INSERT INTO dbo.Usuarios (Correo, PasswordHash, NombreCompleto, IdMedico)
+VALUES
+    (N'carlos.admin@clinica.com', N'A109E36947AD56DE1DCA1CC49F0EF8AC9AD9A7B1AA0DF41FB3C4CB73C1FF01EA',
+     N'Carlos Andrés Ramírez González', NULL),
+    (N'lucia.admin@clinica.com', N'A109E36947AD56DE1DCA1CC49F0EF8AC9AD9A7B1AA0DF41FB3C4CB73C1FF01EA',
+     N'Lucía Herrera Mendoza', NULL),
+    (N'juan.admin@clinica.com', N'A109E36947AD56DE1DCA1CC49F0EF8AC9AD9A7B1AA0DF41FB3C4CB73C1FF01EA',
+     N'Juan Pablo Gómez Ríos', NULL),
+    (N'ana.admin@clinica.com', N'A109E36947AD56DE1DCA1CC49F0EF8AC9AD9A7B1AA0DF41FB3C4CB73C1FF01EA',
+     N'Ana Laura Salinas Cano', NULL),
+    (N'roberto.admin@clinica.com', N'A109E36947AD56DE1DCA1CC49F0EF8AC9AD9A7B1AA0DF41FB3C4CB73C1FF01EA',
+     N'Roberto Cárdenas López', NULL),
+    (N'sofia.medico@clinica.com', N'A109E36947AD56DE1DCA1CC49F0EF8AC9AD9A7B1AA0DF41FB3C4CB73C1FF01EA',
+     N'Sofía Isabel Morales Quintero', 6),
+    (N'marco.medico@clinica.com', N'A109E36947AD56DE1DCA1CC49F0EF8AC9AD9A7B1AA0DF41FB3C4CB73C1FF01EA',
+     N'Marco Antonio Silva Campos', 7),
+    (N'elena.medico@clinica.com', N'A109E36947AD56DE1DCA1CC49F0EF8AC9AD9A7B1AA0DF41FB3C4CB73C1FF01EA',
+     N'Elena Pérez Valdez', 8),
+    (N'diego.medico@clinica.com', N'A109E36947AD56DE1DCA1CC49F0EF8AC9AD9A7B1AA0DF41FB3C4CB73C1FF01EA',
+     N'Diego Armando Navarro Ibáñez', 9),
+    (N'valeria.medico@clinica.com', N'A109E36947AD56DE1DCA1CC49F0EF8AC9AD9A7B1AA0DF41FB3C4CB73C1FF01EA',
+     N'Valeria Noemí Blanco Serrano', 10);
 GO
 
 IF OBJECT_ID('dbo.spRegistrarUsuario', 'P') IS NOT NULL DROP PROCEDURE dbo.spRegistrarUsuario;


### PR DESCRIPTION
## Summary
- remove the foreign key constraint from `Usuarios.IdMedico`
- seed the Medicos, Pacientes, and Usuarios tables with dummy data tied to medical names
- store the authenticated user's full name and show it in the dashboard greeting

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68df09e002c0832397374cba920280d2