### PR TITLE
Adjust frontend default API port selection

### DIFF
--- a/clinicaweb/src/stores/auth.ts
+++ b/clinicaweb/src/stores/auth.ts
@@ -25,10 +25,14 @@ const getDefaultBaseUrl = () => {
   }
 
   if (typeof window !== 'undefined') {
-    return `${window.location.protocol}//${window.location.hostname}:5000`
+    const protocol = window.location.protocol
+    const hostname = window.location.hostname
+    const port = protocol === 'https:' ? '7149' : '5075'
+
+    return `${protocol}//${hostname}:${port}`
   }
 
-  return 'http://localhost:5000'
+  return 'http://localhost:5075'
 }
 
 const apiClient = axios.create({


### PR DESCRIPTION
## Summary
- update the frontend auth store to derive the default API port from the current protocol
- default to the backend's HTTP port when no window object is available

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df109d2fa48323828dd3e8f847f446