### PR TITLE
Add Consultorio Médico logo to home header

### DIFF
--- a/clinicaweb/src/assets/consultorio-medico-logo.svg
+++ b/clinicaweb/src/assets/consultorio-medico-logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180" role="img" aria-labelledby="title desc">
+  <title id="title">Consultorio Médico</title>
+  <desc id="desc">Logo con fondo azul y las palabras Consultorio Médico en blanco con una sonrisa.</desc>
+  <rect width="320" height="180" rx="36" fill="#0B6EDB" />
+  <text x="50%" y="72" fill="#fff" font-family="'Montserrat', 'Segoe UI', sans-serif" font-size="44" font-weight="700" text-anchor="middle">Consultorio</text>
+  <text x="50%" y="128" fill="#fff" font-family="'Montserrat', 'Segoe UI', sans-serif" font-size="58" font-weight="700" text-anchor="middle">Médico</text>
+  <path d="M100 144c18 18 52 30 60 30s42-12 60-30" fill="none" stroke="#fff" stroke-width="12" stroke-linecap="round" />
+</svg>

--- a/clinicaweb/src/views/HomeView.vue
+++ b/clinicaweb/src/views/HomeView.vue
@@ -3,11 +3,11 @@
     <div class="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(58,58,255,0.35),_transparent_60%)]"></div>
     <header class="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-10 md:flex-row md:items-center md:justify-between">
       <div class="flex items-center gap-4">
-        <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-brand-500/10 text-brand-300">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-7" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-          </svg>
-        </div>
+        <img
+          src="@/assets/consultorio-medico-logo.svg"
+          alt="Consultorio Médico"
+          class="h-12 w-auto rounded-2xl shadow-lg shadow-brand-500/30"
+        />
         <div>
           <p class="font-display text-2xl font-semibold tracking-tight">Clínica Integral Aurora</p>
           <p class="text-sm text-slate-400">Tecnología y calidez para tu bienestar</p>


### PR DESCRIPTION
## Summary
- add an SVG recreation of the Consultorio Médico logo to the web app assets
- render the new logo in the home view header next to the clinic name

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df203572348323b78b3ee0f233d930